### PR TITLE
docs: Add README, LICENSE, and F-Droid description

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+# IntruderSelfie
+
 IntruderSelfie silently snaps a front-camera photo **every time the screen is unlocked** with a precise timestamp.
+
+![Screenshot](en-US/images/phoneScreenshots/1.png)
 
 ## Key points
 * Runs as a **lightweight foreground service** after device boot – no need to keep the app open.
@@ -15,3 +19,6 @@ IntruderSelfie silently snaps a front-camera photo **every time the screen is un
 ## Privacy & Security
 - No analytics, trackers, or background network traffic.
 - Source code is publicly available for review.
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This commit adds the following files:
- README.md: A comprehensive overview of the app, its features, and how it works.
- LICENSE: The MIT License for the project.
- en-US/full_description.txt: A detailed description for the F-Droid store.