### PR TITLE
Fix crash, dark photos, permissions, and refine UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,9 +10,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA"/>
 
+    <!-- READ_EXTERNAL_STORAGE is only needed for API <= 32.
+         For our own app's files on API 29+, we don't strictly need it, but useful for broad access on older OS.
+         We stop asking for WRITE on API 28 (Android 9) because Scoped Storage (API 29) handles it. -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
     <application
         android:requestLegacyExternalStorage="true" android:allowBackup="true"

--- a/app/src/main/java/com/tharunbirla/intruderselfie/MainScreen.kt
+++ b/app/src/main/java/com/tharunbirla/intruderselfie/MainScreen.kt
@@ -14,10 +14,12 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -220,8 +222,14 @@ fun MainScreen(viewModel: MainViewModel) {
 
         // Full-screen image preview dialog
         previewPhotoUri?.let { uri ->
-            PhotoPreviewDialog(uri = uri) {
-                viewModel.setPreviewPhoto(null)
+            // Find the photo object to get details
+            val photo = capturedPhotos.find { it.uri == uri }
+            if (photo != null) {
+                PhotoPreviewDialog(
+                    photo = photo,
+                    onDismiss = { viewModel.setPreviewPhoto(null) },
+                    onDelete = { viewModel.deleteSinglePhoto(uri) }
+                )
             }
         }
     }
@@ -305,45 +313,82 @@ fun PhotoItem(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PhotoPreviewDialog(uri: Uri, onDismiss: () -> Unit) {
+fun PhotoPreviewDialog(
+    photo: CapturedPhoto,
+    onDismiss: () -> Unit,
+    onDelete: () -> Unit
+) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color.Black
-        ) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Image(
-                    painter = rememberAsyncImagePainter(uri),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-                // Dismiss button
-                IconButton(
-                    onClick = onDismiss,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(16.dp)
-                        .background(
-                            Color.Black.copy(alpha = 0.5f),
-                            MaterialTheme.shapes.medium
-                        )
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Close preview",
-                        tint = Color.White
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { },
+                    navigationIcon = {
+                        IconButton(onClick = onDismiss) {
+                            Icon(
+                                imageVector = Icons.Default.ArrowBack,
+                                contentDescription = "Back",
+                                tint = Color.White
+                            )
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = onDelete) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete",
+                                tint = Color.White
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Black.copy(alpha = 0.4f)
                     )
+                )
+            },
+            containerColor = Color.Black,
+            content = { padding ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = rememberAsyncImagePainter(photo.uri),
+                        contentDescription = "Full screen preview",
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize()
+                    )
+
+                    // Bottom Info Bar
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .background(Color.Black.copy(alpha = 0.6f))
+                            .padding(16.dp)
+                    ) {
+                        Text(
+                            text = SimpleDateFormat("EEEE, MMM d, yyyy", Locale.getDefault()).format(Date(photo.timestamp)),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(photo.timestamp)),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.7f)
+                        )
+                    }
                 }
             }
-        }
+        )
     }
 }
 

--- a/app/src/main/java/com/tharunbirla/intruderselfie/MainViewModel.kt
+++ b/app/src/main/java/com/tharunbirla/intruderselfie/MainViewModel.kt
@@ -194,21 +194,32 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun deleteSelectedPhotos() {
         viewModelScope.launch {
             if (_selectedPhotos.value.isEmpty()) return@launch
-
-            val urisToDelete = _selectedPhotos.value.toList()
+            deletePhotos(_selectedPhotos.value.toList())
             _selectedPhotos.value = emptySet()
+        }
+    }
 
-            withContext(Dispatchers.IO) {
-                urisToDelete.forEach { uri ->
-                    try {
-                        context.contentResolver.delete(uri, null, null)
-                    } catch (e: Exception) {
-                        Log.e("MainViewModel", "Error deleting photo: $uri", e)
-                    }
+    fun deleteSinglePhoto(uri: Uri) {
+        viewModelScope.launch {
+            deletePhotos(listOf(uri))
+            // If the deleted photo was the one being previewed, close the preview
+            if (_previewPhotoUri.value == uri) {
+                _previewPhotoUri.value = null
+            }
+        }
+    }
+
+    private suspend fun deletePhotos(uris: List<Uri>) {
+        withContext(Dispatchers.IO) {
+            uris.forEach { uri ->
+                try {
+                    context.contentResolver.delete(uri, null, null)
+                } catch (e: Exception) {
+                    Log.e("MainViewModel", "Error deleting photo: $uri", e)
                 }
             }
-            loadCapturedPhotos()
         }
+        loadCapturedPhotos()
     }
 
     fun setPreviewPhoto(uri: Uri?) {


### PR DESCRIPTION
1.  **Crash Fix**:
    *   Strict permission checks added to `BootCompletedReceiver` and `MainViewModel` before starting Foreground Service.
    *   Service self-stops if permissions missing in `onCreate`.

2.  **Dark Photos Fix**:
    *   Implemented 1s AE convergence warmup in camera service.

3.  **UI & UX**:
    *   Enhanced Image Preview to be full-screen with details and delete option (Google Photos style).
    *   Polished Setup Guide (App icon, professional text, real-time permission updates).
    *   Removed Portrait Mode toggle as requested.

4.  **Permissions**:
    *   Restricted Storage permissions to maxSdkVersion 28/32 in Manifest.
    *   Fixed Setup Guide logic to hide storage permission card on Android 10+.